### PR TITLE
chore(pin): throw if custom passcode dismissed

### DIFF
--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -59,10 +59,12 @@ export class LoginPage {
     try {
       return await this.identity.restoreSession();
     } catch (error) {
-      alert('Unable to unlock the token');
-      this.setUnlockType();
       if (this.notFailedOrCancelled(error)) {
         throw error;
+      }
+      if (error.code === VaultErrorCodes.AuthFailed) {
+        alert('Unable to unlock the token');
+        this.setUnlockType();
       }
     }
   }

--- a/src/app/services/identity/identity.service.ts
+++ b/src/app/services/identity/identity.service.ts
@@ -143,7 +143,12 @@ export class IdentityService extends IonicIdentityVaultUser<DefaultSession> {
       }
     });
     dlg.present();
-    const { data } = await dlg.onDidDismiss();
+    const { data, role } = await dlg.onDidDismiss();
+    if (role === 'cancel')
+      throw {
+        code: VaultErrorCodes.UserCanceledInteraction,
+        message: 'User has canceled supplying the application passcode'
+      };
     return Promise.resolve(data || '');
   }
 


### PR DESCRIPTION
This Pull Request throws an error if the user decides to dismiss the custom passcode dialog without submitting a value (i.e., tapping the 'X' icon when the prompt is overlayed). 